### PR TITLE
fix podmonitor podMetricsEndpoints

### DIFF
--- a/chart/k8skeycloak-controller/Chart.yaml
+++ b/chart/k8skeycloak-controller/Chart.yaml
@@ -12,4 +12,4 @@ keywords:
 name: k8skeycloak-controller
 sources:
 - https://github.com/DoodleScheduling/k8skeycloak-controller
-version: 0.1.1
+version: 0.1.2

--- a/chart/k8skeycloak-controller/templates/podmonitor.yaml
+++ b/chart/k8skeycloak-controller/templates/podmonitor.yaml
@@ -17,7 +17,7 @@ metadata:
   annotations:
     {{- toYaml .Values.annotations | nindent 4 }}
 spec:
-  endpoints:
+  podMetricsEndpoints:
   - port: metrics
     path: {{ .Values.metricsPath }}
     interval: {{ .Values.podMonitor.interval }}


### PR DESCRIPTION
## Current situation
`endpoints` is invalid in podMonitor.

## Proposal
Update specs using podMetricsEndpoints.